### PR TITLE
Updating tiny-lru & re-enabling it's test

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ We can group the results in a few categories:
 
 * all rounders (hashlru, lru-native, modern-lru, lru-cache) where the performance
   to add update and evict are comparable.
-* fast-write, slow-evict (lru_cache, tiny-lur, lru, simple-lru-cache, lru-fast) these have better set/update times, but for some reason are quite slow to evict items!
+* fast-write, slow-evict (lru_cache, tiny-lru, lru, simple-lru-cache, lru-fast) these have better set/update times, but for some reason are quite slow to evict items!
 * slow in at least 2 categories (mkc, faster-lur-cache, secondary-cache)
 
 ## Discussion

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var algs = {
   'modern-lru': function (n) { return new Modern(n) },
   'lru-cache': LruCache,
   'lru_cache': function (n) { return new LRU_Cache(n) },
-//  'tiny-lru': tinyLRU,
+  'tiny-lru': tinyLRU,
   'lru': LRU,
   'simple-lru-cache': function (n) { return new Simple({maxSize: n}) },
   'mkc': function (n) { return new MKC({max: n}) },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "modern-lru": "^1.0.8",
     "secondary-cache": "^1.2.1",
     "simple-lru-cache": "0.0.2",
-    "tiny-lru": "^1.3.3",
+    "tiny-lru": "^1.4.1",
     "tiny-lru-cache": "^1.0.1"
   },
   "devDependencies": {},


### PR DESCRIPTION
Hi,

Thanks for making this benchmark! It was very useful in correcting `tiny-lru`!

- [x] Updates the version of tiny-lru in `package.json`
- [x] Re-enables it's test (no longer throws)
- [x] Fixes a typo
- [x] See #4 