### PR TITLE
Bench adjustment discussion + adding mnemonist to bench

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ const Worker = require('tiny-worker'),
     'quick-lru',
     'secondary-cache',
     'simple-lru-cache',
-    'tiny-lru'
+    'tiny-lru',
+    'mnemonist'
   ],
   nth = caches.length;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1333,6 +1333,14 @@
         "minimist": "0.0.8"
       }
     },
+    "mnemonist": {
+      "version": "0.23.0-beta1",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.23.0-beta1.tgz",
+      "integrity": "sha512-OgUwLDyweR4u3Ayky2JLiKmtFdWuGyO/tALO+WgXNSDhhSFPjkL//5lnTKVaNYkJqVyD/2htpVGnGrrZe4iAog==",
+      "requires": {
+        "obliterator": "1.3.0"
+      }
+    },
     "modern-lru": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/modern-lru/-/modern-lru-1.2.0.tgz",
@@ -1383,6 +1391,11 @@
         "has-symbols": "1.0.0",
         "object-keys": "1.0.11"
       }
+    },
+    "obliterator": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.3.0.tgz",
+      "integrity": "sha512-lUSE420rF+gOCNDVn6w+E0ZE2wCtRInrhUETW8cQMjh9Je2EM/Agz0rAWEBr5AmqUP6PlJt1X8hRbMFSewMXSQ=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lrucache": "^1.0.3",
     "markdown-tables": "^1.1.4",
     "mkc": "^1.3.0",
+    "mnemonist": "0.23.0-beta1",
     "modern-lru": "^1.2.0",
     "ora": "^2.0.0",
     "precise": "^1.1.0",

--- a/worker.js
+++ b/worker.js
@@ -12,6 +12,7 @@ const precise = require('precise'),
   MKC = require('mkc'),
   hyperlruObject = hyperlru(require('hyperlru-object')),
   hyperlruMap = hyperlru(require('hyperlru-map')),
+  Mnemonist = require('mnemonist/lru-cache'),
   caches = {
     'lru-cache': () => require('lru-cache'),
     'lru-fast': n => new Fast(n),
@@ -26,7 +27,8 @@ const precise = require('precise'),
     'hyperlru-map': max => hyperlruMap({max}),
     lru_cache: n => new LRUCache(n),
     lru: require('lru'),
-    mkc: max => new MKC({max})
+    mkc: max => new MKC({max}),
+    mnemonist: n => new Mnemonist(n)
   },
   num = 2e5,
   evicts = num * 4,

--- a/worker.js
+++ b/worker.js
@@ -29,13 +29,12 @@ const precise = require('precise'),
     mkc: max => new MKC({max})
   },
   num = 2e5,
-  evicts = num * 2,
+  evicts = num * 4,
   times = 5,
   x = 1e6;
 
 self.onmessage = function (ev) {
   const id = ev.data,
-    lru = caches[id](num),
     time = {
       'set': [],
       get1: [],
@@ -55,6 +54,8 @@ self.onmessage = function (ev) {
   let n = -1;
 
   while (++n < times) {
+    const lru = caches[id](num);
+
     let stimer = precise().start();
     for (let i = 0; i < num; i++) lru.set(i, Math.random());
     time.set.push(stimer.stop().diff() / x);


### PR DESCRIPTION
Hello everyone,

So, I drafted some lru cache implementation for the [mnemonist](https://yomguithereal.github.io/mnemonist/) library using some idea I had and that we can further discuss if you feel it worthy. (I added it to the benchmark so you can test it on your end)

However, I had one issue with the current benchmark being:

set operations are only "raw" the first time since the cache is the same for each run and this means having an outlier in the results (printing the array of times is a good way to see those outliers and increasing the number of evicts seems to flatten differences).

So, as I understand that benchmarking evictions is an important part of this (and indeed, "raw" sets are marginally interesting), I tried to change some things and test the results. I therefore tried to instantiate the cache for each run and doubled the number of evictions to avoid weird optimizations.

Those are the results I had (once again results on macbook + node v10):

*Original*

| name                                                               | set   | get1  | update | get2  | evict |
|--------------------------------------------------------------------|-------|-------|--------|-------|-------|
| [tiny-lru](https://www.npmjs.com/package/tiny-lru)                 | 20683 | 21882 | 26631  | 24938 | 21053 |
| [lru_cache](https://www.npmjs.com/package/lru_cache)               | 18198 | 24301 | 7890   | 27473 | 16681 |
| [mnemonist](https://www.npmjs.com/package/mnemonist)               | 9606  | 77220 | 31201  | 80645 | 8745  |
| [simple-lru-cache](https://www.npmjs.com/package/simple-lru-cache) | 7413  | 36036 | 23447  | 37453 | 6601  |
| [lru-fast](https://www.npmjs.com/package/lru-fast)                 | 4553  | 32206 | 26247  | 30912 | 5301  |
| [hashlru](https://www.npmjs.com/package/hashlru)                   | 6231  | 8333  | 4237   | 7030  | 4748  |
| [quick-lru](https://www.npmjs.com/package/quick-lru)               | 3342  | 3406  | 4314   | 3598  | 4490  |
| [js-lru](https://www.npmjs.com/package/js-lru)                     | 1561  | 5986  | 6935   | 8764  | 1836  |
| [lru](https://www.npmjs.com/package/lru)                           | 2102  | 4700  | 4113   | 4734  | 1742  |
| [secondary-cache](https://www.npmjs.com/package/secondary-cache)   | 2255  | 8285  | 4900   | 7930  | 1569  |
| [hyperlru-object](https://www.npmjs.com/package/hyperlru-object)   | 1637  | 8885  | 14524  | 15492 | 1453  |
| [hyperlru-map](https://www.npmjs.com/package/hyperlru-map)         | 1005  | 5136  | 5378   | 5680  | 994   |
| [mkc](https://www.npmjs.com/package/mkc)                           | 1004  | 1815  | 1131   | 1769  | 826   |
| [modern-lru](https://www.npmjs.com/package/modern-lru)             | 722   | 1482  | 1981   | 2277  | 753   |

*True raw sets (meaning re-instantiating the cache each run)*

| name                                                               | set   | get1  | update | get2  | evict |
|--------------------------------------------------------------------|-------|-------|--------|-------|-------|
| [mnemonist](https://www.npmjs.com/package/mnemonist)               | 13661 | 65789 | 32310  | 80972 | 7025  |
| [tiny-lru](https://www.npmjs.com/package/tiny-lru)                 | 4833  | 27248 | 26385  | 26008 | 6969  |
| [hashlru](https://www.npmjs.com/package/hashlru)                   | 3331  | 5661  | 5047   | 7283  | 5713  |
| [quick-lru](https://www.npmjs.com/package/quick-lru)               | 3816  | 3067  | 2988   | 3225  | 4900  |
| [lru-fast](https://www.npmjs.com/package/lru-fast)                 | 8217  | 32468 | 27435  | 29806 | 4040  |
| [simple-lru-cache](https://www.npmjs.com/package/simple-lru-cache) | 4617  | 11325 | 10081  | 19980 | 3824  |
| [lru_cache](https://www.npmjs.com/package/lru_cache)               | 3541  | 27739 | 15186  | 27100 | 2950  |
| [js-lru](https://www.npmjs.com/package/js-lru)                     | 2588  | 5713  | 5703   | 7339  | 1930  |
| [lru](https://www.npmjs.com/package/lru)                           | 3041  | 4697  | 4050   | 4684  | 1690  |
| [secondary-cache](https://www.npmjs.com/package/secondary-cache)   | 2664  | 4091  | 3825   | 8969  | 1593  |
| [hyperlru-object](https://www.npmjs.com/package/hyperlru-object)   | 1470  | 8909  | 11710  | 10400 | 1590  |
| [hyperlru-map](https://www.npmjs.com/package/hyperlru-map)         | 1364  | 4769  | 4878   | 4394  | 970   |
| [mkc](https://www.npmjs.com/package/mkc)                           | 1463  | 1855  | 1086   | 1935  | 805   |
| [modern-lru](https://www.npmjs.com/package/modern-lru)             | 1403  | 2286  | 1983   | 2355  | 756   |

*True raw sets + doubled evicts*

| name                                                               | set   | get1  | update | get2  | evict |
|--------------------------------------------------------------------|-------|-------|--------|-------|-------|
| [mnemonist](https://www.npmjs.com/package/mnemonist)               | 12005 | 75758 | 31898  | 78125 | 2288  |
| [simple-lru-cache](https://www.npmjs.com/package/simple-lru-cache) | 3797  | 25510 | 9311   | 20243 | 1691  |
| [lru-fast](https://www.npmjs.com/package/lru-fast)                 | 5893  | 29240 | 26385  | 30488 | 1565  |
| [tiny-lru](https://www.npmjs.com/package/tiny-lru)                 | 9132  | 26525 | 24876  | 25707 | 1423  |
| [quick-lru](https://www.npmjs.com/package/quick-lru)               | 3145  | 3408  | 3219   | 3348  | 1276  |
| [hashlru](https://www.npmjs.com/package/hashlru)                   | 5972  | 7596  | 3980   | 6741  | 1246  |
| [lru_cache](https://www.npmjs.com/package/lru_cache)               | 3739  | 21930 | 8985   | 22857 | 1156  |
| [js-lru](https://www.npmjs.com/package/js-lru)                     | 2922  | 5819  | 7516   | 7421  | 624   |
| [lru](https://www.npmjs.com/package/lru)                           | 2093  | 4006  | 3926   | 4119  | 588   |
| [secondary-cache](https://www.npmjs.com/package/secondary-cache)   | 2369  | 5225  | 4700   | 8621  | 553   |
| [hyperlru-object](https://www.npmjs.com/package/hyperlru-object)   | 1698  | 8326  | 9116   | 13652 | 526   |
| [hyperlru-map](https://www.npmjs.com/package/hyperlru-map)         | 1197  | 5576  | 4562   | 4935  | 302   |
| [mkc](https://www.npmjs.com/package/mkc)                           | 1218  | 1571  | 1047   | 1815  | 265   |
| [modern-lru](https://www.npmjs.com/package/modern-lru)             | 1455  | 2188  | 1940   | 2189  | 240   |

Sorry if I am still missing something obvious and if I messed things up while doing the benchmark.

Also, if I switch my implementation to `Map`, I become less efficient with numbers but more efficient with strings.