### PR TITLE
Adding mnemonist to the bench

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,27 +30,29 @@ I run a very simple multi-process benchmark, with 5 iterations to get a median o
 Operations per millisecond (*higher is better*):
 
 
-| name                                                           | set  | get1  | update | get2  | evict |
-|----------------------------------------------------------------|------|-------|--------|-------|-------|
-| [lru_cache](https://npmjs.com/package/lru_cache)               | 3436 | 19084 | 5105   | 19417 | 9425  |
-| [tiny-lru](https://npmjs.com/package/tiny-lru)                 | 5993 | 20790 | 21692  | 18797 | 5157  |
-| [simple-lru-cache](https://npmjs.com/package/simple-lru-cache) | 3204 | 24783 | 16639  | 40984 | 4962  |
-| [lru-cache](https://npmjs.com/package/lru-cache)               | 2096 | 2694  | 2901   | 2978  | 4183  |
-| [quick-lru](https://npmjs.com/package/quick-lru)               | 2601 | 2510  | 2764   | 2742  | 3342  |
-| [hashlru](https://npmjs.com/package/hashlru)                   | 5222 | 6135  | 3039   | 3656  | 2751  |
-| [lru-fast](https://npmjs.com/package/lru-fast)                 | 2157 | 28612 | 17905  | 31104 | 2650  |
-| [hyperlru-object](https://npmjs.com/package/hyperlru-object)   | 1971 | 7728  | 5663   | 8396  | 2282  |
-| [js-lru](https://www.npmjs.com/package/quick-lru)              | 1205 | 2448  | 2422   | 2224  | 1527  |
-| [lru](https://www.npmjs.com/package/lru)                       | 1309 | 3359  | 2675   | 3664  | 1456  |
-| [secondary-cache](https://npmjs.com/package/secondary-cache)   | 1583 | 4132  | 3489   | 4128  | 1170  |
-| [hyperlru-map](https://npmjs.com/package/hyperlru-map)         | 1076 | 2869  | 2268   | 3439  | 1112  |
-| [modern-lru](https://npmjs.com/package/modern-lru)             | 639  | 2352  | 1612   | 2276  | 710   |
-| [mkc](https://npmjs.com/packacge/package/mkc)                  | 673  | 1114  | 773    | 1241  | 630   |
+| name                                                           | set   | get1  | update | get2  | evict |
+|----------------------------------------------------------------|-------|-------|--------|-------|-------|
+| [lru_cache](https://npmjs.com/package/lru_cache)               | 13432 | 29240 | 7527   | 30075 | 12523 |
+| [mnemonist-object](https://www.npmjs.com/package/mnemonist)    | 9877  | 93458 | 33445  | 90090 | 8997  |
+| [simple-lru-cache](https://npmjs.com/package/simple-lru-cache) | 6131  | 34072 | 19980  | 38911 | 6754  |
+| [lru-cache](https://npmjs.com/package/lru-cache)               | 3500  | 5212  | 4122   | 4588  | 6402  |
+| [lru-fast](https://npmjs.com/package/lru-fast)                 | 5164  | 33058 | 27211  | 27701 | 5729  |
+| [hashlru](https://npmjs.com/package/hashlru)                   | 3701  | 7020  | 4644   | 7505  | 5705  |
+| [tiny-lru](https://npmjs.com/package/tiny-lru)                 | 17575 | 25806 | 25806  | 23838 | 5260  |
+| [quick-lru](https://npmjs.com/package/quick-lru)               | 4003  | 3197  | 4787   | 3352  | 4803  |
+| [hyperlru-object](https://npmjs.com/package/hyperlru-object)   | 2667  | 6971  | 12399  | 13928 | 3512  |
+| [mnemonist-map](https://www.npmjs.com/package/mnemonist)       | 3750  | 14337 | 10817  | 15198 | 3262  |
+| [js-lru](https://www.npmjs.com/package/js-lru)                 | 1701  | 4084  | 4124   | 4847  | 1960  |
+| [lru](https://www.npmjs.com/package/lru)                       | 2048  | 4723  | 3366   | 4745  | 1953  |
+| [secondary-cache](https://npmjs.com/package/secondary-cache)   | 2106  | 7587  | 4526   | 9255  | 1544  |
+| [hyperlru-map](https://npmjs.com/package/hyperlru-map)         | 1406  | 3015  | 3716   | 4193  | 1299  |
+| [mkc](https://npmjs.com/packacge/package/mkc)                  | 976   | 1918  | 1139   | 1915  | 854   |
+| [modern-lru](https://npmjs.com/package/modern-lru)             | 796   | 2981  | 2824   | 3012  | 836   |
 
 
 We can group the results in a few categories:
 
-* all rounders (lru_cache, tiny-lru, simple-lru-cache, lru-fast) where the performance to add update and evict are comparable.
+* all rounders (mnemonist, lru_cache, tiny-lru, simple-lru-cache, lru-fast) where the performance to add update and evict are comparable.
 * fast-write, slow-evict (lru, hashlru, lru-native, modern-lru) these have better set/update times, but for some reason are quite slow to evict items!
 * slow in at least 2 categories (lru-cache, mkc, faster-lru-cache, secondary-cache)
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ const Worker = require('tiny-worker'),
     'secondary-cache',
     'simple-lru-cache',
     'tiny-lru',
-    'mnemonist'
+    'mnemonist-object',
+    'mnemonist-map'
   ],
   nth = caches.length;
 

--- a/index.js
+++ b/index.js
@@ -2,24 +2,25 @@
 
 const Worker = require('tiny-worker'),
   ora = require('ora'),
-  caches = [
-    'hashlru',
-    'hyperlru-map',
-    'hyperlru-object',
-    'js-lru',
-    'lru',
-    'lru-cache',
-    'lru-fast',
-    'lru_cache',
-    'mkc',
-    'modern-lru',
-    'quick-lru',
-    'secondary-cache',
-    'simple-lru-cache',
-    'tiny-lru',
-    'mnemonist-object',
-    'mnemonist-map'
-  ],
+  meta = {
+    'hashlru': {url: 'https://npmjs.com/package/hashlru'},
+    'hyperlru-map': {url: 'https://npmjs.com/package/hyperlru-map'},
+    'hyperlru-object': {url: 'https://npmjs.com/package/hyperlru-object'},
+    'js-lru': {url: 'https://www.npmjs.com/package/js-lru'},
+    'lru': {url: 'https://www.npmjs.com/package/lru'},
+    'lru-cache': {url: 'https://npmjs.com/package/lru-cache'},
+    'lru-fast': {url: 'https://npmjs.com/package/lru-fast'},
+    'lru_cache': {url: 'https://npmjs.com/package/lru_cache'},
+    'mkc': {url: 'https://npmjs.com/packacge/package/mkc'},
+    'modern-lru': {url: 'https://npmjs.com/package/modern-lru'},
+    'quick-lru': {url: 'https://npmjs.com/package/quick-lru'},
+    'secondary-cache': {url: 'https://npmjs.com/package/secondary-cache'},
+    'simple-lru-cache': {url: 'https://npmjs.com/package/simple-lru-cache'},
+    'tiny-lru': {url: 'https://npmjs.com/package/tiny-lru'},
+    'mnemonist-object': {url: 'https://www.npmjs.com/package/mnemonist'},
+    'mnemonist-map': {url: 'https://www.npmjs.com/package/mnemonist'}
+  },
+  caches = Object.keys(meta),
   nth = caches.length;
 
 const spinner = ora(`Starting benchmark of ${nth} caches`).start(),
@@ -40,7 +41,7 @@ caches.forEach((i, idx) => {
         worker.terminate();
       };
 
-      spinner.text = `Benchmarking ${idx + 1} of ${nth} caches`;
+      spinner.text = `Benchmarking ${idx + 1} of ${nth} caches [${i}]`;
       worker.postMessage(i);
     }).catch(reject);
   }));
@@ -51,7 +52,7 @@ Promise.all(promises).then(results => {
     keysort = require('keysort');
 
   spinner.stop();
-  console.log(toMD(['name,set,get1,update,get2,evict'].concat(keysort(results.map(i => JSON.parse(i)), 'evict desc, set desc, get1 desc, update desc, get2 desc').map(i => `${i.name},${i.set},${i.get1},${i.update},${i.get2},${i.evict}`)).join('\n')));
+  console.log(toMD(['name,set,get1,update,get2,evict'].concat(keysort(results.map(i => JSON.parse(i)), 'evict desc, set desc, get1 desc, update desc, get2 desc').map(i => `[${i.name}](${meta[i.name].url}),${i.set},${i.get1},${i.update},${i.get2},${i.evict}`)).join('\n')));
 }).catch(err => {
   console.error(err.stack || err.message || err);
   process.exit(1);

--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ const Worker = require('tiny-worker'),
     'quick-lru',
     'secondary-cache',
     'simple-lru-cache',
-    'tiny-lru'
+    'tiny-lru',
+    'mnemonist'
   ],
   nth = caches.length;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1278,6 +1278,14 @@
         "minimist": "0.0.8"
       }
     },
+    "mnemonist": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.25.0.tgz",
+      "integrity": "sha512-2FULta2BffBuzjlEdK5nL8lPDdAWg/dzJUzPWfpY2xG9Z2xULVkJXTf3eZJjR4ATt2XD/tM94zP6tne1MqXkhg==",
+      "requires": {
+        "obliterator": "^1.4.0"
+      }
+    },
     "modern-lru": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/modern-lru/-/modern-lru-1.3.0.tgz",
@@ -1328,6 +1336,11 @@
         "has-symbols": "^1.0.0",
         "object-keys": "^1.0.11"
       }
+    },
+    "obliterator": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.5.0.tgz",
+      "integrity": "sha512-dENe0UviDf8/auXn0bIBKwCcUr49khvSBWDLlszv/ZB2qz1VxWDmkNKFqO2nfmve7hQb/QIDY7+rc7K3LdJimQ=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lrucache": "^1.0.3",
     "markdown-tables": "^1.1.4",
     "mkc": "^1.3.0",
+    "mnemonist": "^0.25.0",
     "modern-lru": "^1.2.0",
     "ora": "^2.0.0",
     "precise": "^1.1.0",

--- a/worker.js
+++ b/worker.js
@@ -13,6 +13,7 @@ const precise = require('precise'),
   hyperlruObject = hyperlru(require('hyperlru-object')),
   hyperlruMap = hyperlru(require('hyperlru-map')),
   MnemonistLRUCache = require('mnemonist/lru-cache'),
+  MnemonistLRUMap = require('mnemonist/lru-map'),
   caches = {
     'lru-cache': () => require('lru-cache')(),
     'lru-fast': n => new Fast(n),
@@ -28,7 +29,8 @@ const precise = require('precise'),
     lru_cache: n => new LRUCache(n),
     lru: require('lru'),
     mkc: max => new MKC({max}),
-    mnemonist: n => new MnemonistLRUCache(n)
+    'mnemonist-object': n => new MnemonistLRUCache(n),
+    'mnemonist-map': n => new MnemonistLRUMap(n)
   },
   num = 2e5,
   evicts = num * 2,

--- a/worker.js
+++ b/worker.js
@@ -12,6 +12,7 @@ const precise = require('precise'),
   MKC = require('mkc'),
   hyperlruObject = hyperlru(require('hyperlru-object')),
   hyperlruMap = hyperlru(require('hyperlru-map')),
+  MnemonistLRUCache = require('mnemonist/lru-cache'),
   caches = {
     'lru-cache': () => require('lru-cache')(),
     'lru-fast': n => new Fast(n),
@@ -26,7 +27,8 @@ const precise = require('precise'),
     'hyperlru-map': max => hyperlruMap({max}),
     lru_cache: n => new LRUCache(n),
     lru: require('lru'),
-    mkc: max => new MKC({max})
+    mkc: max => new MKC({max}),
+    mnemonist: n => new MnemonistLRUCache(n)
   },
   num = 2e5,
   evicts = num * 2,


### PR DESCRIPTION
Just adding the [mnemonist](https://yomguithereal.github.io/mnemonist/) library to the benchmark. The library also has a variant relying on `ES6` Map that could maybe fare better with issues discussed in #20.

The results I get on a 2013 MacBook Pro:

```
| name             | set   | get1  | update | get2  | evict |
|------------------|-------|-------|--------|-------|-------|
| lru_cache        | 12763 | 26350 | 6789   | 27473 | 13123 |
| mnemonist-object | 9162  | 90909 | 33333  | 90498 | 9095  |
| simple-lru-cache | 6090  | 29762 | 19608  | 34904 | 6831  |
| lru-cache        | 3883  | 4482  | 4109   | 5648  | 6254  |
| lru-fast         | 4739  | 33501 | 27663  | 27933 | 5472  |
| tiny-lru         | 17361 | 24814 | 25608  | 22883 | 5172  |
| hashlru          | 3537  | 6510  | 4790   | 7660  | 4995  |
| quick-lru        | 4200  | 3580  | 4674   | 2949  | 4485  |
| hyperlru-object  | 2667  | 10035 | 12376  | 13689 | 3913  |
| mnemonist-map    | 3782  | 15083 | 12330  | 16000 | 3507  |
| js-lru           | 1597  | 4839  | 4008   | 5822  | 1946  |
| lru              | 2123  | 4544  | 4006   | 4143  | 1824  |
| secondary-cache  | 2035  | 8074  | 4387   | 8961  | 1588  |
| hyperlru-map     | 1398  | 3804  | 4121   | 4620  | 1539  |
| modern-lru       | 759   | 3317  | 2655   | 3090  | 836   |
| mkc              | 950   | 1711  | 1087   | 1867  | 820   |
```