### PR TITLE
Correctly instantiating `lru-cache`

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -2,6 +2,7 @@
 
 const precise = require('precise'),
   retsu = require('retsu'),
+  LRUCacheHyphen = require('lru-cache'),
   LRUCache = require('lru_cache').LRUCache,
   Simple = require('simple-lru-cache'),
   Fast = require('lru-fast').LRUCache,
@@ -13,7 +14,7 @@ const precise = require('precise'),
   hyperlruObject = hyperlru(require('hyperlru-object')),
   hyperlruMap = hyperlru(require('hyperlru-map')),
   caches = {
-    'lru-cache': () => require('lru-cache')(),
+    'lru-cache': n => new LRUCacheHyphen(n),
     'lru-fast': n => new Fast(n),
     'js-lru': n => new LRUMap(n),
     'modern-lru': n => new Modern(n),


### PR DESCRIPTION
As per the [lru-cache](https://github.com/isaacs/node-lru-cache) library docs, shouldn't we instantiate the cache for this library like this PR proposes?

Else, as per [this](https://github.com/isaacs/node-lru-cache/blob/master/index.js#L38) line of code, I guess the cache has an infinite capacity and will not evict anything.